### PR TITLE
Fix tso_perturbed leakage test0

### DIFF
--- a/tso_perturbed.als
+++ b/tso_perturbed.als
@@ -469,8 +469,8 @@ let interesting_not_axiom{
 
 // Find tests that contain leakage but were sorted out because they are not minimal
 run test0{
-  leakage and not interesting_not_axiom[] and #Event = 2
-} for 2
+  leakage and not interesting_not_axiom[] and #Event = 3
+} for 3
 
 // Find tests that are minimal with respect to leakage
 run test1{


### PR DESCRIPTION
This commit fixes the model size for `tso_perturbed.als`. With a model size of two, the only two possible configurations of `tfo` are:

1. CacheFlush and a Read or Write in the same thread.
2. CacheFlush and a Read or Write in different threads.

Neither of these configurations generate leakage instances.