### PR TITLE
Update Leakage Definition in lcm_skeleton.als

### DIFF
--- a/lcm_skeleton.als
+++ b/lcm_skeleton.als
@@ -243,8 +243,8 @@ pred first_initialization_access[e1 : Event]
 pred intervening_access[e1 : Event, e2 : Event]{
   e1->e2 in com_arch and 
  {some e3:Event| disj[e3,e1] and disj[e3,e2] 
-  and e1->e3 not in  ^com_arch and e3->e1 in ecomx 
-  and e3 in eXSWriters}
+  and e1->e3 not in  ^com_arch and e3->e2 in ecomx 
+  and e3 in eXSWriters} // TODO: Add constraints that e3, e1 and e2 - all have access to the same xstate location.
 }
 
 // Whenever there is no corresponding comx edge for its respective com counterpart, the architectural communication is inconsistent with the extra-architecural communication


### PR DESCRIPTION
We expect to have e3 to be an intevening access (interfering access) that disrupts the extra-architectural flow of information between e1 and e2. If so, we require (e3--[ecomx]-->e2) rather than saying that (e3--[ecomx]-->e1). Additionally, why do we not have explicit statements that constrain e1, e2 and e3 are events that access the same xstate-location?